### PR TITLE
Correct bug in examples and add Travis-ci and also add reading power outage timestamps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - "~/.platformio"
+
+env:
+    - PLATFORMIO_CI_SRC=examples/alarm.ino
+    - PLATFORMIO_CI_SRC=examples/clock.ino
+    - PLATFORMIO_CI_SRC=examples/tm_format.ino
+
+install:
+    - pip install -U platformio
+
+script:
+    - platformio ci --lib=. --board=megaatmega2560 --board uno

--- a/RTCC_MCP7940N.h
+++ b/RTCC_MCP7940N.h
@@ -141,7 +141,7 @@ public:
 	 *
 	 * @return 				True if a power fail event has been detected
 	 */
-	bool HasPowerFailed();
+	bool HasPowerFailed(rtcc_time *dwTime, rtcc_time *upTime);
 
 	/**
 	 * Clear the power failure flag so it can be raised again if another failure is detected

--- a/examples/alarm.ino
+++ b/examples/alarm.ino
@@ -7,7 +7,7 @@
 
 #define PIN_INT 	(3)
 
-RTCC_MCP7940N rtc();
+RTCC_MCP7940N rtc;
 
 volatile bool itr = false;
 

--- a/examples/clock.ino
+++ b/examples/clock.ino
@@ -5,7 +5,7 @@
 #include <Wire.h>
 #include <RTCC_MCP7940N.h>
 
-RTCC_MCP7940N rtc();
+RTCC_MCP7940N rtc;
 
 void setup()
 {

--- a/examples/power_outage.ino
+++ b/examples/power_outage.ino
@@ -1,0 +1,52 @@
+/* Part of RTCC (MCP7940N) Arduino library
+ * Copyright (C) 2017 Kane Wallmann
+ * See LICENCE.txt for license (MIT)*/
+
+#include <Wire.h>
+#include <RTCC_MCP7940N.h>
+
+RTCC_MCP7940N rtc;
+
+void setup()
+{
+	Serial.begin(9600);
+
+	// Must call before using rtcc
+	Wire.begin();
+
+	// Use crystal for timekeeping
+	rtc.SetOscillatorEnabled(true);
+	rtc.SetExternalOscillatorEnabled(false);
+}
+
+void loop()
+{
+	char buff[20];
+	bool pwrOutage;
+
+	// rtcc_time struct represents how the data is stored on RTCC chip, see tm_format example for info on converting
+	rtcc_time time, dwTime, upTime;
+	rtc.ReadTime(&time);
+
+	sprintf(buff, "%u%u-%u%u-%u%u %u%u:%u%u:%u%u", time.dateten, time.dateone, time.mthten, time.mthone, time.yrten,
+			time.yrone, time.hrten, time.hrone, time.minten, time.minone, time.secten, time.secone);
+	Serial.println(buff);
+
+	pwrOutage = rtc.HasPowerFailed(&dwTime, &upTime);
+	if (pwrOutage) {
+	    Serial.println("*****NEW OUTAGE*****");
+	}
+	else {
+	    Serial.println("LastOutage: ");
+	}
+	Serial.print("    From: ");
+	sprintf(buff, "%u%u-%u%u-%u%u %u%u:%u%u:%u%u", dwTime.dateten, dwTime.dateone, dwTime.mthten, dwTime.mthone, dwTime.yrten,
+			dwTime.yrone, dwTime.hrten, dwTime.hrone, dwTime.minten, dwTime.minone, dwTime.secten, dwTime.secone);
+	Serial.println(buff);
+	Serial.print("    To: ");
+	sprintf(buff, "%u%u-%u%u-%u%u %u%u:%u%u:%u%u", upTime.dateten, upTime.dateone, upTime.mthten, upTime.mthone, upTime.yrten,
+			upTime.yrone, upTime.hrten, upTime.hrone, upTime.minten, upTime.minone, upTime.secten, upTime.secone);
+	Serial.println(buff);
+
+	delay(10000);
+}

--- a/examples/tm_format.ino
+++ b/examples/tm_format.ino
@@ -6,7 +6,7 @@
 #include <RTCC_MCP7940N.h>
 #include <time.h>
 
-RTCC_MCP7940N rtc();
+RTCC_MCP7940N rtc;
 
 void setup()
 {
@@ -30,7 +30,7 @@ void loop()
 
 	// Covner to tm format
 	tm tm_time;
-	rtc.ConverTime( &time, &tm_time );
+	rtc.ConvertTime( &time, &tm_time );
 
 	// Format time and output to string
 	strftime( buff, 20, "%d-%m-%y %H:%M:%s", &tm_time );


### PR DESCRIPTION
This PR correct [object declaration](https://stackoverflow.com/questions/877523/error-request-for-member-in-which-is-of-non-class-type) on examples, and also a typo in one of them.

The main goal is to provide Travis-ci.org support, so please, after merge, enable travis-ci on this repository as [explained here](https://docs.travis-ci.com/user/getting-started/) steps 1., 2. and 5.

Also close #1 by adding reading power outage time-stamps feature.

Thanks.